### PR TITLE
Revert "Support shared theta and tau covariance params."

### DIFF
--- a/R/default-inits.R
+++ b/R/default-inits.R
@@ -21,10 +21,10 @@ default_inits_pgLM <- function(Y, X, priors) {
 #' @param Y is a \eqn{n \times d}{n x d} matrix of multinomial count data.
 #' @param X is a \eqn{n \times p}{n x p} matrix of variables.
 #' @param priors
-#' @param shared_theta
-#' @param shared_tau
+#' @param corr_fun
+#' @param shared_covariance_params
 #' @noRd
-default_inits_pgSPLM <- function(Y, X, priors, corr_fun = "exponential", shared_theta, shared_tau) {
+default_inits_pgSPLM <- function(Y, X, priors, corr_fun = "exponential", shared_covariance_params = TRUE) {
 
     J <- ncol(Y)
     theta_mean <- NULL
@@ -39,12 +39,12 @@ default_inits_pgSPLM <- function(Y, X, priors, corr_fun = "exponential", shared_
     
     inits <- list(
         beta  = t(mvnfast::rmvn(J-1, priors$mu_beta, priors$Sigma_beta)),
-        tau2  = if (shared_tau) {
+        tau2  = if (shared_covariance_params) {
             min(1 / rgamma(1, priors$alpha_tau, priors$beta_tau), 10)
         } else {
             pmin(1 / rgamma(J-1, priors$alpha_tau, priors$beta_tau), 10)
         },
-        theta = if (shared_theta) {
+        theta = if (shared_covariance_params) {
             if (corr_fun == "matern") {
                 as.vector(pmin(pmax(mvnfast::rmvn(1, theta_mean, theta_var), -1), 0.1))
             } else if (corr_fun == "exponential") {

--- a/R/pgSPLM.R
+++ b/R/pgSPLM.R
@@ -1,23 +1,23 @@
 #' Bayesian Polya-gamma regression
-#'
+#' 
 #' this function runs the Bayesian multinomial regression using Polya-gamma data augmentation
 #' @param Y is a \eqn{n \times J}{n x J} matrix of compositional count data.
 #' @param X is a \eqn{n \times p}{n x p} matrix of climate variables.
 #' @param locs is a \eqn{n \times 2}{n x 2} matrix of observation locations.
 #' @param params is the list of parameter settings.
-#' @param priors is the list of prior settings.
+#' @param priors is the list of prior settings. 
 #' @param corr_fun is a character that denotes the correlation function form. Current options include "matern" and "exponential".
 #' @param n_cores is the number of cores for parallel computation using openMP.
 #' @param inits is the list of intial values if the user wishes to specify initial values. If these values are not specified, then the intital values will be randomly sampled from the prior.
 #' @param config is the list of configuration values if the user wishes to specify initial values. If these values are not specified, then default a configuration will be used.
-#' @param shared_covariance_params is a logicial input that determines whether to fit the spatial process with component specifice parameters. If TRUE, each component has conditionally independent Gaussian process parameters theta and tau2. If FALSE, all components share the same Gaussian process parameters theta and tau2.
+#' @param shared_covariance_params is a logicial input that determines whether to fit the spatial process with component specifice parameters. If TRUE, each component has conditionally independent Gaussian process parameters theta and tau2. If FALSE, all components share the same Gaussian process parameters theta and tau2. 
 #' @param progress is a logicial input that determines whether to print a progress bar.
-#'
+#' 
 ## polya-gamma spatial linear regression model
 pgSPLM <- function(
-    Y,
+    Y, 
     X,
-    locs,
+    locs, 
     params,
     priors,
     corr_fun = "exponential",
@@ -26,65 +26,59 @@ pgSPLM <- function(
     inits = NULL,
     config = NULL,
     n_chain       = 1,
-    shared_tau = FALSE,
-    shared_theta = FALSE,
-    progress = FALSE,
-    verbose = FALSE
+    verbose = FALSE,
+    progress = FALSE
     # pool_s2_tau2  = true,
     # file_name     = "DM-fit",
     # corr_function = "exponential"
 ) {
-
+    
     ##
     ## Run error checks
-    ##
-
-    if ((shared_theta) & (!shared_tau)) {
-        # Error message?
-    }
-
+    ## 
+    
     check_input_spatial(Y, X, locs)
     check_params(params)
     check_corr_fun(corr_fun)
     # check_inits_pgLM(params, inits)
     # check_config(params, config)
-
+    
     ## add in faster parallel cholesky as needed
-
+    
     ## add in a counter for the number of regularized Cholesky
     num_chol_failures <- 0
-
-
+    
+    
     N  <- nrow(Y)
     J  <- ncol(Y)
     p <- ncol(X)
     D <- fields::rdist(locs)
-
+    
     ## Calculate Mi
     Mi <- matrix(0, N, J-1)
     for(i in 1: N){
         Mi[i,] <- sum(Y[i, ]) - c(0, cumsum(Y[i,][1:(J-2)]))
     }
-
+    
     ## create an index for nonzero values
     nonzero_idx <- Mi != 0
-
+    
     ## initialize kappa
     kappa <- matrix(0, N, J-1)
     for (i in 1: N) {
         kappa[i,] <- Y[i, 1:(J - 1)]- Mi[i, ] / 2
     }
-
+    
     ##
     ## initial values
     ##
-
+    
     ## currently using default priors
-
+    
     mu_beta        <- rep(0, p)
-
+    
     ## do I want to change this to be a penalized spline?
-    # Q_beta <- make_Q(params$p, 1)
+    # Q_beta <- make_Q(params$p, 1) 
     Sigma_beta     <- 10 * diag(p)
     ## clean up this check
     if (!is.null(priors$mu_beta)) {
@@ -92,7 +86,7 @@ pgSPLM <- function(
             mu_beta <- priors$mu_beta
         }
     }
-
+    
     ## clean up this check
     if (!is.null(priors$Sigma_beta)) {
         if (all(!is.na(priors$Sigma_beta))) {
@@ -104,15 +98,15 @@ pgSPLM <- function(
         error = function(e) {
             if (verbose)
                 message("The Cholesky decomposition of the prior covariance Sigma_beta was ill-conditioned and mildy regularized.")
-            chol(Sigma_beta + 1e-8 * diag(N))
+            chol(Sigma_beta + 1e-8 * diag(N))                    
         }
     )
     Sigma_beta_inv  <- chol2inv(Sigma_beta_chol)
-
+    
     ##
     ## initialize beta
     ##
-
+    
     beta <- t(mvnfast::rmvn(J-1, mu_beta, Sigma_beta_chol, isChol = TRUE))
     ## clean up this check
     if (!is.null(inits$beta)) {
@@ -121,7 +115,7 @@ pgSPLM <- function(
         }
     }
     Xbeta <- X %*% beta
-
+    
     ##
     ## initialize spatial Gaussian process -- share parameters across the different components
     ##    can generalize to each component getting its own covariance
@@ -138,11 +132,11 @@ pgSPLM <- function(
     ## This was swapped in an older commit; the above is the correct order -- remove the comment in later commits
     # theta_mean <- c(priors$mean_nu, priors$mean_range)
     # theta_var  <- diag(c(priors$sd_nu, priors$sd_range)^2)
-
+    
     theta <- NULL
-    if (shared_theta) {
+    if (shared_covariance_params) {
         if (corr_fun == "matern") {
-            theta <- as.vector(pmin(pmax(mvnfast::rmvn(1, theta_mean, theta_var), -2), 0.1))
+            theta <- as.vector(pmin(pmax(mvnfast::rmvn(1, theta_mean, theta_var), -2), 0.1))            
         } else if (corr_fun == "exponential") {
             theta <- pmin(pmax(rnorm(1, theta_mean, sqrt(theta_var)), -2), 0.1)
         }
@@ -152,33 +146,33 @@ pgSPLM <- function(
         } else if (corr_fun == "exponential") {
             theta <- pmin(pmax(rnorm(J-1, theta_mean, sqrt(theta_var)), -2), 0.1)
         }
-
+        
     }
-
+    
     if (!is.null(inits$theta)) {
         if (all(!is.na(inits$theta))) {
             theta <- inits$theta
         }
     }
     ## check dimensions of theta
-    if (shared_theta) {
+    if (shared_covariance_params) {
         if (corr_fun == "matern")
-            if (!is_numeric_vector(theta, 2))
-                stop('If shared_theta is TRUE, theta must be a numeric vector of length 2 when corr_fun is "matern"')
+            if (!is_numeric_vector(theta, 2)) 
+                stop('If shared_covariance_params is TRUE, theta must be a numeric vector of length 2 when corr_fun is "matern"')
         if (corr_fun == "exponential")
-            if (!is_numeric_vector(theta, 1))
-                stop('If shared_theta is TRUE, theta must be a numeric of length 1 when corr_fun is "exponential"')
+            if (!is_numeric_vector(theta, 1)) 
+                stop('If shared_covariance_params is TRUE, theta must be a numeric of length 1 when corr_fun is "exponential"')
     } else {
         if (corr_fun == "matern")
             if (!is_numeric_matrix(theta, J-1, 2))
-                stop('If shared_theta is FALSE, theta must be a J-1 by 2 numeric matrix when corr_fun is "matern"')
+                stop('If shared_covariance_params is FALSE, theta must be a J-1 by 2 numeric matrix when corr_fun is "matern"')
         if (corr_fun == "exponential")
-            if (!is_numeric_vector(theta, J-1))
-                stop('If shared_theta is FALSE, theta must be a numeric vector of length J-1 when corr_fun is "exponential"')
+            if (!is_numeric_vector(theta, J-1)) 
+                stop('If shared_covariance_params is FALSE, theta must be a numeric vector of length J-1 when corr_fun is "exponential"')
     }
-
+    
     tau2 <- NULL
-    if (shared_tau) {
+    if (shared_covariance_params) {
         tau2 <- min(1 / rgamma(1, priors$alpha_tau, priors$beta_tau), 10)
     } else {
         tau2 <- pmin(1 / rgamma(J-1, priors$alpha_tau, priors$beta_tau), 10)
@@ -189,26 +183,21 @@ pgSPLM <- function(
             tau2 <- inits$tau2
         }
     }
-
+    
     ## check dimensions of tau2
-    if (shared_tau) {
+    if (shared_covariance_params) {
         if (!is_positive_numeric(tau2, 1))
-            stop("If shared_tau is FALSE, tau2 must be a numeric scalar")
+            stop("If shared_covariance_params is FALSE, tau2 must be a numeric scalar")
     } else {
         if (!is_positive_numeric(tau2, J-1))
-            stop("If shared_tau is TRUE, tau2 must be a J-1 positive numeric vector ")
+            stop("If shared_covariance_params is TRUE, tau2 must be a J-1 positive numeric vector ")
     }
-
-
+    
+    
     Sigma <- NULL
-    if (shared_theta & shared_tau) {
+    if (shared_covariance_params) {
         Sigma <- tau2 * correlation_function(D, theta, corr_fun = corr_fun)
-    } else if ((!shared_theta) & (shared_tau)) {
-        Sigma <- array(0, dim = c(J-1, N, N))
-        for (j in 1:(J-1)) {
-            Sigma[j, , ] <- tau2 * correlation_function(D, theta[j, ], corr_fun = corr_fun)
-        }
-    } else if ((!shared_theta) & (!shared_tau)) {
+    } else {
         Sigma <- array(0, dim = c(J-1, N, N))
         for (j in 1:(J-1)) {
             if (corr_fun == "matern") {
@@ -217,20 +206,20 @@ pgSPLM <- function(
                 Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j], corr_fun = corr_fun)
             }
         }
-        # Sigma <- sapply(1:(J-1), function(j) tau2[j] * correlation_function(D, theta[j, ]))
+        # Sigma <- sapply(1:(J-1), function(j) tau2[j] * correlation_function(D, theta[j, ]))        
     }
-
-
-
+    
+    
+    
     Sigma_chol <- NULL
-    if (shared_theta & shared_tau) {
+    if (shared_covariance_params) {
         Sigma_chol <- tryCatch(
             chol(Sigma[j, , ]),
             error = function(e) {
                 if (verbose)
                     message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                 num_chol_failures <- num_chol_failures + 1
-                chol(Sigma + 1e-8 * diag(N))
+                chol(Sigma + 1e-8 * diag(N))                    
             }
         )
     } else {
@@ -243,25 +232,25 @@ pgSPLM <- function(
                     if (verbose)
                         message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                     num_chol_failures <- num_chol_failures + 1
-                    chol(Sigma[j, , ] + 1e-8 * diag(N))
+                    chol(Sigma[j, , ] + 1e-8 * diag(N))                    
                 }
             )
         }
     }
-
+    
     Sigma_inv  <- NULL
-    if (shared_theta & shared_tau) {
-        Sigma_inv <- chol2inv(Sigma_chol)
+    if (shared_covariance_params) {
+        Sigma_inv <- chol2inv(Sigma_chol)   
     } else {
         Sigma_inv <- array(0, dim = c(J-1, N, N))
         for (j in 1:(J-1)) {
             Sigma_inv[j, , ] <- chol2inv(Sigma_chol[j, , ])
         }
     }
-
-
+    
+    
     eta  <- NULL
-    if (shared_theta & shared_tau) {
+    if (shared_covariance_params) {
         eta <- Xbeta + t(rmvn(J-1, rep(0, N), Sigma_chol, isChol = TRUE))
     } else{
         eta <- matrix(0, N, J-1)
@@ -269,49 +258,49 @@ pgSPLM <- function(
             eta[, j] <- Xbeta[, j] + t(rmvn(1, rep(0, N), Sigma_chol[j, , ], isChol = TRUE))
         }
     }
-
+    
     ##
     ## sampler config options -- to be added later
-    ##
+    ## 
     #
     # bool sample_beta = true;
     # if (params.containsElementNamed("sample_beta")) {
     #     sample_beta = as<bool>(params["sample_beta"]);
     # }
-    #
-
+    # 
+    
     ##
     ## initialize omega
     ##
-
+    
     omega <- matrix(0, N, J-1)
     omega[nonzero_idx] <- pgdraw(Mi[nonzero_idx], eta[nonzero_idx], cores = n_cores)
-
+    
     if (!is.null(inits$omega)) {
         if (!is.na(inits$omega)) {
             omega <- inits$omega
         }
     }
-
+    
     Omega <- vector(mode = "list", length = J-1)
     for (j in 1:(J - 1)) {
         Omega[[j]] <- diag(omega[, j])
     }
-
+    
     ##
     ## setup save variables
     ##
-
+    
     n_save     <- params$n_mcmc / params$n_thin
     beta_save  <- array(0, dim = c(n_save, p, J-1))
     tau2_save  <- NULL
-    if (shared_tau) {
+    if (shared_covariance_params) {
         tau2_save <- rep(0, n_save)
     } else {
         tau2_save <- matrix(0, n_save, J-1)
     }
     theta_save <- NULL
-    if (shared_theta) {
+    if (shared_covariance_params) {
         if (corr_fun == "matern") {
             theta_save <- matrix(0, n_save, 2)
         } else if (corr_fun == "exponential") {
@@ -325,15 +314,15 @@ pgSPLM <- function(
         }
     }
     eta_save   <- array(0, dim = c(n_save, N, J-1))
-
+    
+    ## 
+    ## initialize tuning 
     ##
-    ## initialize tuning
-    ##
-
+    
     ##
     ## tuning variables for adaptive MCMC
     ##
-
+    
     theta_batch           <- NULL
     theta_accept          <- NULL
     theta_accept_batch    <- NULL
@@ -341,14 +330,14 @@ pgSPLM <- function(
     Sigma_theta_tune      <- NULL
     Sigma_theta_tune_chol <- NULL
     theta_tune            <- NULL
-
-    if (shared_theta) {
-
+    
+    if (shared_covariance_params) {
+        
         theta_accept       <- 0
         theta_accept_batch <- 0
-
+        
         if (corr_fun == "matern") {
-            theta_batch <- matrix(0, 50, 2)
+            theta_batch <- matrix(0, 50, 2) 
             lambda_theta          <- 0.05
             Sigma_theta_tune      <- 1.8 * diag(2) - .8
             Sigma_theta_tune_chol <- tryCatch(
@@ -356,20 +345,20 @@ pgSPLM <- function(
                 error = function(e) {
                     if (verbose)
                         message("The Cholesky decomposition of the Metroplois-Hastings adaptive tuning matrix for Matern parameters theta was ill-conditioned and mildy regularized.")
-                    chol(Sigma_theta_tune + 1e-8 * diag(2))
+                    chol(Sigma_theta_tune + 1e-8 * diag(2))                    
                 }
             )
         } else if (corr_fun == "exponential") {
             theta_tune <- 1.5
         }
-
+        
     } else {
-
+        
         theta_accept       <- rep(0, J-1)
         theta_accept_batch <- rep(0, J-1)
-
+        
         if (corr_fun == "matern") {
-            theta_batch <- array(0, dim = c(50, 2, J-1))
+            theta_batch <- array(0, dim = c(50, 2, J-1))      
             lambda_theta     <- rep(0.05, J-1)
             Sigma_theta_tune <- array(0, dim = c(2, 2, J-1))
             for (j in 1:(J-1)) {
@@ -382,7 +371,7 @@ pgSPLM <- function(
                     error = function(e) {
                         if (verbose)
                             message("The Cholesky decomposition of the Metroplois-Hastings adaptive tuning matrix for Matern parameters theta was ill-conditioned and mildy regularized.")
-                        chol(Sigma_theta_tune[, , j] + 1e-8 * diag(2))
+                        chol(Sigma_theta_tune[, , j] + 1e-8 * diag(2))                    
                     }
                 )
             }
@@ -390,18 +379,18 @@ pgSPLM <- function(
             theta_tune <- rep(0.5, J-1)
         }
     }
-
+    
     ##
     ## Starting MCMC chain
     ##
-
+    
     message("Starting MCMC for chain ", n_chain, ", running for ", params$n_adapt, " adaptive iterations and ", params$n_mcmc, " fitting iterations \n")
     if (progress) {
         progressBar <- txtProgressBar(style = 3)
     }
     percentage_points <- round((1:100 / 100) * (params$n_adapt + params$n_mcmc))
-
-
+    
+    
     for (k in 1:(params$n_adapt + params$n_mcmc)) {
         if (k == params$n_adapt + 1) {
             message("Starting MCMC fitting for chain ", n_chain, ", running for ", params$n_mcmc, " iterations \n")
@@ -413,15 +402,15 @@ pgSPLM <- function(
                 message("MCMC fitting iteration ", k - params$n_adapt, " for chain ", n_chain)
             }
         }
-
+        
         ##
         ## sample Omega
         ##
         if (verbose)
             message("sample omega")
-
+        
         omega[nonzero_idx] <- pgdraw(Mi[nonzero_idx], eta[nonzero_idx], cores = n_cores)
-
+        
         # for (i in 1:N) {
         #     for (j in 1:(J-1)) {
         #         if (Mi[i, j] != 0){
@@ -432,26 +421,26 @@ pgSPLM <- function(
         #         }
         #     }
         # }
-
+        
         for (j in 1:(J-1)) {
             Omega[[j]] <- diag(omega[, j])
         }
-
+        
         ##
         ## sample beta -- double check these values
         ##
-
+        
         ## modify this for the spatial process eta
-
-        ## parallelize this update -- each group of parameteres is
+        
+        ## parallelize this update -- each group of parameteres is 
         ## conditionally independent given omega and kappa(y)
         if (verbose)
             message("sample beta")
-
-        if (shared_theta & shared_tau) {
+        
+        if (shared_covariance_params) {
             for (j in 1:(J-1)) {
                 ## can make this much more efficient
-                # Sigma_tilde <- chol2inv(chol(Sigma_beta_inv + t(X) %*% (Omega[[j]] %*% X)))
+                # Sigma_tilde <- chol2inv(chol(Sigma_beta_inv + t(X) %*% (Omega[[j]] %*% X))) 
                 # mu_tilde    <- c(Sigma_tilde %*% (Sigma_beta_inv %*% mu_beta + t(X) %*% kappa[, j]))
                 # beta[, j]   <- mvnfast::rmvn(1, mu_tilde, Sigma_tilde)
                 tXSigma_inv <- t(X) %*% Sigma_inv
@@ -464,7 +453,7 @@ pgSPLM <- function(
         } else {
             for (j in 1:(J-1)) {
                 ## can make this much more efficient
-                # Sigma_tilde <- chol2inv(chol(Sigma_beta_inv + t(X) %*% (Omega[[j]] %*% X)))
+                # Sigma_tilde <- chol2inv(chol(Sigma_beta_inv + t(X) %*% (Omega[[j]] %*% X))) 
                 # mu_tilde    <- c(Sigma_tilde %*% (Sigma_beta_inv %*% mu_beta + t(X) %*% kappa[, j]))
                 # beta[, j]   <- mvnfast::rmvn(1, mu_tilde, Sigma_tilde)
                 tXSigma_inv <- t(X) %*% Sigma_inv[j, , ]
@@ -474,22 +463,22 @@ pgSPLM <- function(
                 b <- tXSigma_inv %*% eta[, j] + Sigma_beta_inv %*% mu_beta
                 beta[, j]   <- rmvn_arma(A, b)
             }
-        }
+        }        
         Xbeta <- X %*% beta
-
+        
         ##
         ## sample spatial correlation parameters theta
         ##
-
+        
         if (verbose)
             message("sample theta")
-
-        if (shared_theta & shared_tau) {
+        
+        if (shared_covariance_params) {
             ## update a common theta for all processes
             theta_star <- NULL
             if (corr_fun == "matern") {
                 theta_star <- as.vector(
-                    rmvn(
+                    rmvn( 
                         n      = 1,
                         mu     = theta,
                         sigma  = lambda_theta * Sigma_theta_tune_chol,
@@ -507,23 +496,23 @@ pgSPLM <- function(
                     if (verbose)
                         message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                     num_chol_failures <- num_chol_failures + 1
-                    chol(Sigma_star + 1e-8 * diag(N))
+                    chol(Sigma_star + 1e-8 * diag(N))                    
                 }
             )
             Sigma_inv_star  <- chol2inv(Sigma_chol_star)
             ## parallelize this
             mh1 <- sum(
                 sapply(
-                    1:(J-1),
+                    1:(J-1), 
                     function(j) {
                         mvnfast::dmvn(eta[, j], Xbeta[, j], Sigma_chol_star, isChol = TRUE, log = TRUE, ncores = n_cores) }
                 )
             ) +
                 ## prior
                 mvnfast::dmvn(theta_star, theta_mean, theta_var, log = TRUE)
-            ## parallelize this
+            ## parallelize this        
             mh2 <- sum(
-                sapply(
+                sapply( 
                     1:(J-1),
                     function(j) {
                         mvnfast::dmvn(eta[, j], Xbeta[, j], Sigma_chol, isChol = TRUE, log = TRUE, ncores = n_cores)
@@ -532,13 +521,13 @@ pgSPLM <- function(
             ) +
                 ## prior
                 mvnfast::dmvn(theta, theta_mean, theta_var, log = TRUE)
-
+            
             mh <- exp(mh1 - mh2)
             if (mh > runif(1, 0, 1)) {
                 theta      <- theta_star
                 Sigma      <- Sigma_star
                 Sigma_chol <- Sigma_chol_star
-                Sigma_inv  <- Sigma_inv_star
+                Sigma_inv  <- Sigma_inv_star 
                 if (k <= params$n_adapt) {
                     theta_accept_batch <- theta_accept_batch + 1 / 50
                 } else {
@@ -550,9 +539,9 @@ pgSPLM <- function(
                 save_idx <- k %% 50
                 if ((k %% 50) == 0) {
                     save_idx <- 50
-                }
+                } 
                 if (corr_fun == "matern") {
-                    theta_batch[save_idx, ] <- theta
+                    theta_batch[save_idx, ] <- theta 
                     if (k %% 50 == 0) {
                         out_tuning <- update_tuning_mv(
                             k,
@@ -567,22 +556,22 @@ pgSPLM <- function(
                         Sigma_theta_tune_chol <- out_tuning$Sigma_tune_chol
                         lambda_theta          <- out_tuning$lambda
                         theta_accept_batch    <- out_tuning$accept
-                    }
-                }
+                    } 
+                }   
             } else if (corr_fun == "exponential") {
                 out_tuning <- update_tuning(k, theta_accept_batch, theta_tune)
                 theta_tune         <- out_tuning$tune
                 theta_accept_batch <- out_tuning$accept
             }
-        } else if (!shared_theta) {
-            ##
-            ## theta or tau varies for each component
+        } else {
+            ## 
+            ## theta varies for each component
             ##
             for (j in 1:(J-1)) {
                 theta_star <- NULL
                 if (corr_fun == "matern") {
                     theta_star <- as.vector(
-                        rmvn(
+                        rmvn( 
                             n      = 1,
                             mu     = theta[j, ],
                             sigma  = lambda_theta[j] * Sigma_theta_tune_chol[, , j],
@@ -592,13 +581,8 @@ pgSPLM <- function(
                 } else if (corr_fun == "exponential") {
                     theta_star <- rnorm(1, theta[j], theta_tune)
                 }
-
-                if (shared_tau) {
-                    Sigma_star      <- tau2 * correlation_function(D, theta_star, corr_fun = corr_fun)
-                } else {
-                    Sigma_star      <- tau2[j] * correlation_function(D, theta_star, corr_fun = corr_fun)
-                }
-
+                
+                Sigma_star      <- tau2[j] * correlation_function(D, theta_star, corr_fun = corr_fun)
                 ## add in faster parallel cholesky as needed
                 Sigma_chol_star <- tryCatch(
                     chol(Sigma_star),
@@ -606,7 +590,7 @@ pgSPLM <- function(
                         if (verbose)
                             message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                         num_chol_failures <- num_chol_failures + 1
-                        chol(Sigma_star + 1e-8 * diag(N))
+                        chol(Sigma_star + 1e-8 * diag(N))                    
                     }
                 )
                 Sigma_inv_star  <- chol2inv(Sigma_chol_star)
@@ -614,7 +598,7 @@ pgSPLM <- function(
                 mh1 <- mvnfast::dmvn(eta[, j], Xbeta[, j], Sigma_chol_star, isChol = TRUE, log = TRUE, ncores = n_cores) +
                     ## prior
                     mvnfast::dmvn(theta_star, theta_mean, theta_var, log = TRUE)
-                ## parallelize this
+                ## parallelize this        
                 mh2 <- mvnfast::dmvn(eta[, j], Xbeta[, j], Sigma_chol[j, , ], isChol = TRUE, log = TRUE, ncores = n_cores) +
                     ## prior
                     if (corr_fun == "matern") {
@@ -622,7 +606,7 @@ pgSPLM <- function(
                     } else if (corr_fun == "exponential") {
                         dnorm(theta[j], theta_mean, sqrt(theta_var), log = TRUE)
                     }
-
+                
                 mh <- exp(mh1 - mh2)
                 if (mh > runif(1, 0, 1)) {
                     if (corr_fun == "matern") {
@@ -632,7 +616,7 @@ pgSPLM <- function(
                     }
                     Sigma[j, , ]      <- Sigma_star
                     Sigma_chol[j, , ] <- Sigma_chol_star
-                    Sigma_inv[j, , ]  <- Sigma_inv_star
+                    Sigma_inv[j, , ]  <- Sigma_inv_star 
                     if (k <= params$n_adapt) {
                         theta_accept_batch[j] <- theta_accept_batch[j] + 1 / 50
                     } else {
@@ -645,11 +629,11 @@ pgSPLM <- function(
                 save_idx <- k %% 50
                 if ((k %% 50) == 0) {
                     save_idx <- 50
-                }
+                } 
                 if (corr_fun == "matern") {
-                    theta_batch[save_idx, , ] <- theta
+                    theta_batch[save_idx, , ] <- theta 
                     if (k %% 50 == 0) {
-
+                        
                         out_tuning <- update_tuning_mv_mat(
                             k,
                             theta_accept_batch,
@@ -667,25 +651,23 @@ pgSPLM <- function(
                         out_tuning <- update_tuning_vec(k, theta_accept_batch, theta_tune)
                         theta_tune         <- out_tuning$tune
                         theta_accept_batch <- out_tuning$accept
-                    }
-                }
-            }
-        } else if (shared_theta & !shared_tau){
-            # error
-        }
-
+                    } 
+                }   
+            }        
+        }        
+        
         ##
         ## sample spatial process variance tau2
         ##
-
+        
         if (verbose)
             message("sample tau2")
-
-        if (shared_theta & shared_tau) {
+        
+        if (shared_covariance_params) {
             devs       <- eta - Xbeta
             SS         <- sum(devs * (tau2 * Sigma_inv %*% devs))
-            tau2       <- 1 / rgamma(1, N * (J-1) / 2 + priors$alpha_tau, SS / 2 + priors$beta_tau)
-            Sigma      <- tau2 * correlation_function(D, theta, corr_fun = corr_fun)
+            tau2       <- 1 / rgamma(1, N * (J-1) / 2 + priors$alpha_tau, SS / 2 + priors$beta_tau) 
+            Sigma      <- tau2 * correlation_function(D, theta, corr_fun = corr_fun) 
             ## add in faster parallel cholesky as needed
             ## see https://github.com/RfastOfficial/Rfast/blob/master/src/cholesky.cpp
             Sigma_chol <- tryCatch(
@@ -694,46 +676,19 @@ pgSPLM <- function(
                     if (verbose)
                         message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                     num_chol_failures <- num_chol_failures + 1
-                    chol(Sigma + 1e-8 * diag(N))
+                    chol(Sigma + 1e-8 * diag(N))                    
                 }
             )
-            Sigma_inv  <- chol2inv(Sigma_chol)
-        } else if ((!shared_theta) & (shared_tau)){
-            SS <- 0
-            for (j in 1:(J-1)){
-                devs <- eta[ ,j] - Xbeta[,j]
-                devs <- as.matrix(devs)
-                # devs <- kappa - eta[k, , ]
-                # doesn't actually depend on tau[k-1] because Sigma_Inv has a 1/tau[k-1] factor
-                # SS <- sum(devs * (tau[k-1]^2 * Sigma_inv[j,,] %*% as.matrix(devs)))
-                SS <- SS + t(devs) %*% (tau2 * Sigma_inv[j,,] %*% devs)
-            }
-            tau2 <- 1 / rgamma(1, N * (J - 1) / 2 + priors$alpha_tau,
-                               SS / 2 + priors$beta_tau)
-
-            for (j in 1:(J-1)) {
-                Sigma[j, , ] <- tau2 * correlation_function(D, theta[j, ], corr_fun=corr_fun)
-                ## add in faster parallel cholesky as needed
-                ## see https://github.com/RfastOfficial/Rfast/blob/master/src/cholesky.cpp
-                Sigma_chol[j, , ] <- tryCatch(
-                    chol(Sigma[j, , ]),
-                    error = function(e) {
-                        message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
-                        warning("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
-                        chol(Sigma[j, , ] + 1e-8 * diag(N))
-                    }
-                )
-                Sigma_inv[j, , ]  <- chol2inv(Sigma_chol[j, , ])
-            }
+            Sigma_inv  <- chol2inv(Sigma_chol) 
         } else {
             for (j in 1:(J-1)) {
                 devs       <- eta[, j] - Xbeta[, j]
                 SS         <- sum(devs * (tau2[j] * Sigma_inv[j, , ] %*% devs))
-                tau2[j]    <- 1 / rgamma(1, N / 2 + priors$alpha_tau, SS / 2 + priors$beta_tau)
+                tau2[j]    <- 1 / rgamma(1, N / 2 + priors$alpha_tau, SS / 2 + priors$beta_tau) 
                 if (corr_fun == "matern") {
-                    Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j, ], corr_fun = corr_fun)
+                    Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j, ], corr_fun = corr_fun) 
                 } else {
-                    Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j], corr_fun = corr_fun)
+                    Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j], corr_fun = corr_fun) 
                 }
                 ## add in faster parallel cholesky as needed
                 ## see https://github.com/RfastOfficial/Rfast/blob/master/src/cholesky.cpp
@@ -743,28 +698,28 @@ pgSPLM <- function(
                         if (verbose)
                             message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                         num_chol_failures <- num_chol_failures + 1
-                        chol(Sigma[j, , ] + 1e-8 * diag(N))
+                        chol(Sigma[j, , ] + 1e-8 * diag(N))                    
                     }
                 )
                 Sigma_inv[j, , ]  <- chol2inv(Sigma_chol[j, , ])
             }
         }
-
+        
         ##
         ## sample eta
         ##
-
+        
         if (verbose)
             message("sample eta")
-
-        if (shared_theta & shared_tau) {
+        
+        if (shared_covariance_params) {
             ## double check this and add in fixed effects X %*% beta
             for (j in 1:(J-1)) {
                 ## can make this much more efficient
                 ## can this be parallelized? seems like it
                 # A        <- Sigma_inv + Omega[[j]]
                 # b        <- Sigma_inv %*% Xbeta[, j] + kappa[, j]
-                # eta[, j] <- rmvn_arma(A, b)
+                # eta[, j] <- rmvn_arma(A, b) 
                 A <- Sigma_inv + Omega[[j]]
                 A_chol <- tryCatch(
                     chol(A),
@@ -772,22 +727,22 @@ pgSPLM <- function(
                         if (verbose)
                             message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                         num_chol_failures <- num_chol_failures + 1
-                        chol(A + 1e-8 * diag(N))
+                        chol(A + 1e-8 * diag(N))                    
                     }
                 )
                 A_inv <- chol2inv(A_chol)
                 # A_inv <- chol2inv(chol(Sigma_inv + Omega[[j]]))
                 b     <- Sigma_inv %*% Xbeta[, j] + kappa[, j]
-                eta[, j]   <- mvnfast::rmvn(1, A_inv %*% b, A_inv)
+                eta[, j]   <- mvnfast::rmvn(1, A_inv %*% b, A_inv)                
             }
-        } else {
+        } else {      
             for (j in 1:(J-1)) {
                 ## can make this much more efficient
                 ## can this be parallelized? seems like it
-
+                
                 # A        <- Sigma_inv[j, , ] + Omega[[j]]
                 # b        <- Sigma_inv[j, , ] %*% Xbeta[, j] + kappa[, j]
-                # eta[, j] <- rmvn_arma(A, b)
+                # eta[, j] <- rmvn_arma(A, b) 
                 A <- Sigma_inv[j, , ] + Omega[[j]]
                 A_chol <- tryCatch(
                     chol(A),
@@ -795,16 +750,16 @@ pgSPLM <- function(
                         if (verbose)
                             message("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized. If this warning is rare, this should be safe to ignore.")
                         num_chol_failures <- num_chol_failures + 1
-                        chol(A + 1e-8 * diag(N))
+                        chol(A + 1e-8 * diag(N))                    
                     }
                 )
                 A_inv <- chol2inv(A_chol)
                 b     <- Sigma_inv[j, , ] %*% Xbeta[, j] + kappa[, j]
                 eta[, j]   <- mvnfast::rmvn(1, A_inv %*% b, A_inv)
-
+                
             }
         }
-
+        
         ##
         ## save variables
         ##
@@ -812,54 +767,51 @@ pgSPLM <- function(
             if (k %% params$n_thin == 0) {
                 save_idx                <- (k - params$n_adapt) / params$n_thin
                 beta_save[save_idx, , ] <- beta
-                if (shared_theta) {
+                if (shared_covariance_params) {
                     if (corr_fun == "matern") {
                         theta_save[save_idx, ]  <- theta
                     } else if (corr_fun == "exponential") {
                         theta_save[save_idx]  <- theta
                     }
+                    tau2_save[save_idx]     <- tau2
                 } else {
                     if (corr_fun == "matern") {
                         theta_save[save_idx, , ]  <- theta
                     } else if (corr_fun == "exponential") {
                         theta_save[save_idx, ]  <- theta
                     }
-                }
-                if (shared_tau) {
-                    tau2_save[save_idx] <- tau2
-                } else {
-                    tau2_save[save_idx, ] <- tau2
+                    tau2_save[save_idx, ]     <- tau2
                 }
                 eta_save[save_idx, , ]  <- eta
             }
-
+            
         }
-
+        
         ##
         ## End of MCMC loop
         ##
-
+        
         if (k %in% percentage_points && progress) {
             setTxtProgressBar(progressBar, k / (params$n_adapt + params$n_mcmc))
         }
     }
-
+    
     ## print out acceptance rates -- no tuning in this model
-
+    
     if (num_chol_failures > 0)
         warning("The Cholesky decomposition of the Matern correlation function was ill-conditioned and mildy regularized ", num_chol_failures, " times. If this warning is rare, this should be safe to ignore.")
-
+    
     ## eventually create a model class and include this as a variable in the class
     message("Acceptance rate for theta is ", mean(theta_accept))
-
+    
     ##
     ## return the MCMC output -- think about a better way to make this a class
-    ##
-
+    ## 
+    
     if (progress) {
         close(progressBar)
     }
-
+    
     return(
         list(
             beta  = beta_save,
@@ -869,3 +821,5 @@ pgSPLM <- function(
         )
     )
 }
+
+

--- a/scripts/pgSPLM-simulation-exponential.Rmd
+++ b/scripts/pgSPLM-simulation-exponential.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "pgSPLM Simulation"
+title: "pgSPLM Simulation test - exponentisal covariance function"
 bibliography: pg.bib
 output:
   bookdown::html_document2: default
@@ -11,6 +11,7 @@ nocite: '@*'
 We are testing the spatial Polya-gamma linear model `pgSPLM()`
 
 ```{r setup, include=FALSE}
+knitr::opts_chunk$set(fig.width = 16, fig.height = 9)
 library(pgR)
 library(mvnfast)
 # library(MCMCpack)
@@ -31,14 +32,10 @@ locs <- expand.grid(
   seq(0, 1, length = sqrt(N))
 )
 D <- fields::rdist(locs)
-correlation_function <- function(D, theta) {
-  ## calculate the Matern correlation using parameters theta on the log scale 
-  geoR::matern(D, exp(theta[1]), exp(theta[2]))
-}
 ## use the same parameters for each of the d-1 components
 tau2 <- 0.4
-theta <- c(log(0.1), log(1.5)) ## range and smoothness parameter
-Sigma <- tau2 * correlation_function(D, theta) 
+theta <- log(0.1) 
+Sigma <- tau2 * correlation_function(D, theta, corr_fun = "exponential") 
 psi <- t(rmvn(J-1, rep(0, N), Sigma))
 ## setup the fixed effects process
 X <- cbind(1, matrix(runif(N*p), N, p))
@@ -310,20 +307,20 @@ params$n_mcmc <- 1000
 params$n_message <- 50
 params$n_thin <- 1
 priors <- default_priors_pgSPLM(Y, X)
-inits  <- default_inits_pgSPLM(Y, X, priors, shared_theta = TRUE, shared_tau = TRUE)
+inits  <- default_inits_pgSPLM(Y, X, priors, shared_covariance_params = TRUE)
 
-if (file.exists(here::here("results", "pgSPLM-shared.RData"))) {
-  load(here::here("results", "pgSPLM-shared.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential-shared.RData"))) {
+  load(here::here("results", "pgSPLM-exponential-shared.RData"))
 } else {
   ## need to parallelize the polya-gamma random variables
   ## can I do this efficiently using openMP?
   ## Q: faster to parallelize using openMP or foreach?
   start <- Sys.time()
-  out <- pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, n_cores = 1L, shared_theta = TRUE, shared_tau = TRUE)
+  out <- pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, corr_fun = "exponential", n_cores = 6L, shared_covariance_params = TRUE)
   stop <- Sys.time()
   runtime <- stop - start
   
-  save(out, runtime, file = here::here("results", "pgSPLM-shared.RData"))
+  save(out, runtime, file = here::here("results", "pgSPLM-exponential-shared.RData"))
 }
 ```
 
@@ -441,20 +438,20 @@ params$n_mcmc <- 1000
 params$n_message <- 50
 params$n_thin <- 1
 priors <- default_priors_pgSPLM(Y_s, X_s)
-inits <- default_inits_pgSPLM(Y_s, X_s, priors, shared_theta = TRUE, shared_tau = TRUE)
+inits <- default_inits_pgSPLM(Y_s, X_s, priors, shared_covariance_params = TRUE)
 
-if (file.exists(here::here("results", "pgSPLM-sample-shared.RData"))) {
-  load(here::here("results", "pgSPLM-sample-shared.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential-sample-shared.RData"))) {
+  load(here::here("results", "pgSPLM-exponential-sample-shared.RData"))
 } else {
   ## need to parallelize the polya-gamma random variables
   ## can I do this efficiently using openMP?
   ## Q: faster to parallelize using openMP or foreach?
   start <- Sys.time()
-  out <- pgSPLM(Y_s, as.matrix(X_s), as.matrix(locs_s), params, priors, n_cores = 6L, shared_theta = TRUE, shared_tau = TRUE)
+  out <- pgSPLM(Y_s, as.matrix(X_s), as.matrix(locs_s), params, priors, corr_fun = "exponential", n_cores = 6L, shared_covariance_params = TRUE)
   stop <- Sys.time()
   runtime <- stop - start
   
-  save(out, runtime, file = here::here("results", "pgSPLM-sample-shared.RData"))
+  save(out, runtime, file = here::here("results", "pgSPLM-exponential-sample-shared.RData"))
 }
 ```
 
@@ -529,12 +526,12 @@ p1 + p2
 
 
 ```{r}
-if (file.exists(here::here("results", "pgSPLM-sample-preds-shared.RData"))) {
-  load(here::here("results", "pgSPLM-sample-preds-shared.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential-sample-preds-shared.RData"))) {
+  load(here::here("results", "pgSPLM-exponential-sample-preds-shared.RData"))
 } else {
   ## currently this is somewhat slow but is embarassingly parallel
-  preds <- predict_pgSPLM(out, X_s, X_oos, locs_s, locs_oos, shared_covariance_params = TRUE)
-  save(preds, file = here::here("results", "pgSPLM-sample-preds-shared.RData"))
+  preds <- predict_pgSPLM(out, X_s, X_oos, locs_s, locs_oos, corr_fun = "exponential", shared_covariance_params = TRUE)
+  save(preds, file = here::here("results", "pgSPLM-exponential-sample-preds-shared.RData"))
 }
 ```
 
@@ -588,11 +585,11 @@ D <- fields::rdist(locs)
 
 ## use the same parameters for each of the d-1 components
 tau2 <- runif(J-1, 0.25, 1.5)
-theta <- cbind(rnorm(J-1, log(0.1), 0.1), rnorm(J-1, log(1.5), 0.1)) ## range and smoothness parameter
+theta <- rnorm(J-1, log(0.1), 0.1)
 Sigma <- array(0, dim = c(J-1, N, N))
 psi   <- matrix(0, N, J-1)
 for (j in 1:(J-1)) {
-  Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j, ]) 
+  Sigma[j, , ] <- tau2[j] * correlation_function(D, theta[j], corr_fun = "exponential") 
   psi[, j]     <- c(mvnfast::rmvn(1, rep(0, N), Sigma[j, , ]))
 }
 ## setup the fixed effects process
@@ -640,10 +637,10 @@ params$n_mcmc <- 1000
 params$n_message <- 50
 params$n_thin <- 1
 priors <- default_priors_pgSPLM(Y, X)
-inits  <- default_inits_pgSPLM(Y, X, priors, shared_theta = FALSE, shared_tau = TRUE)
+inits  <- default_inits_pgSPLM(Y, X, priors, corr_fun = "exponential", shared_covariance_params = FALSE)
 
-if (file.exists(here::here("results", "pgSPLM.RData"))) {
-  load(here::here("results", "pgSPLM.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential.RData"))) {
+  load(here::here("results", "pgSPLM-exponential.RData"))
 } else {
   ## parallelize the Cholesky decomposition
   ## add in tryCatch checks for all Cholesky decompositions
@@ -653,11 +650,11 @@ if (file.exists(here::here("results", "pgSPLM.RData"))) {
   ## can I do this efficiently using openMP?
   ## Q: faster to parallelize using openMP or foreach?
   start <- Sys.time()
-  out <- pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, n_cores = 1L, shared_theta = FALSE, shared_tau=TRUE, verbose = FALSE)
+  out <- pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, corr_fun = "exponential", n_cores = 6L, shared_covariance_params = FALSE, verbose = FALSE)
   stop <- Sys.time()
   runtime <- stop - start
   
-  save(out, runtime, file = here::here("results", "pgSPLM.RData"))
+  save(out, runtime, file = here::here("results", "pgSPLM-exponential.RData"))
 }
 ```
 
@@ -665,11 +662,20 @@ if (file.exists(here::here("results", "pgSPLM.RData"))) {
 ```{r}
 layout(matrix(1:6, 3, 2))
 for (i in 1:5) {
-  matplot(out$beta[, , i], type = 'l', main = paste("species", i))
+  matplot(out$beta[, , i], type = 'l', main = paste("species", i), col = 1:nrow(beta))
   abline(h = beta[, i], col = 1:nrow(beta))
 }
-matplot(out$theta, type = 'l', main = "theta")
-abline(h = theta, col = 1:2)
+```
+
+```{r}
+
+layout(matrix(1:6, 3, 2))
+for (i in 1:5) {
+  matplot(out$theta[, i], type = 'l', main = "theta")
+  abline(h = theta[i], col = 1:2)
+}
+matplot(out$tau2, type = 'l')
+abline(h = tau2, col = 1:length(tau2))
 ```
 
 ```{r}
@@ -679,14 +685,11 @@ for (i in 1:5) {
   matplot(out$eta[, plot_idx, i], type = 'l', main = paste("species", i))
   abline(h = eta[plot_idx, i], col = 1:20)
 }
-plot(out$tau2, type = 'l', main = "tau2")
-abline(h = tau2, col = "red")
 ```
 
 
 ```{r}
 runtime
-
 
 ## plot beta estimates
 dat_plot <- data.frame(
@@ -694,8 +697,8 @@ dat_plot <- data.frame(
     c(apply(out$beta, c(2, 3), mean)), 
     c(beta)
   ),
-  type = rep(c("estimate", "truth"), each = (d-1) * ncol(X)),
-  species = factor(rep(1:(d-1), each = ncol(X))),
+  type = rep(c("estimate", "truth"), each = (J-1) * ncol(X)),
+  species = factor(rep(1:(J-1), each = ncol(X))),
   variable = 1:ncol(X)
 )
 
@@ -714,8 +717,8 @@ dat_plot <- data.frame(
     c(apply(out$eta, c(2, 3), mean)), 
     c(eta)
   ),
-  type = rep(c("estimate", "truth"), each = (d-1) * N),
-  species = factor(rep(1:(d-1), each = N)),
+  type = rep(c("estimate", "truth"), each = (J-1) * N),
+  species = factor(rep(1:(J-1), each = N)),
   observations = 1:N
 )
 
@@ -755,7 +758,7 @@ dat <- data.frame(
   Y       = c(Y_prop_s),
   lon     = c(locs_s[, 1]),
   lat     = c(locs_s[, 2]),
-  species = factor(rep(1:d, each = n)), 
+  species = factor(rep(1:J, each = n)), 
   pi      = c(pi_s)
 )
 p_observed <- ggplot(data = dat, aes(x = lon, y = lat, fill = pi)) +
@@ -774,20 +777,20 @@ params$n_mcmc <- 1000
 params$n_message <- 50
 params$n_thin <- 1
 priors <- default_priors_pgSPLM(Y_s, X_s)
-inits <- default_inits_pgSPLM(Y_s, X_s, priors, shared_theta = FALSE, shared_tau = TRUE)
+inits <- default_inits_pgSPLM(Y_s, X_s, priors, corr_fun = "exponential", shared_covariance_params = FALSE)
 
-if (file.exists(here::here("results", "pgSPLM-sample.RData"))) {
-  load(here::here("results", "pgSPLM-sample.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential-sample.RData"))) {
+  load(here::here("results", "pgSPLM-exponential-sample.RData"))
 } else {
   ## need to parallelize the polya-gamma random variables
   ## can I do this efficiently using openMP?
   ## Q: faster to parallelize using openMP or foreach?
   start <- Sys.time()
-  out <- pgSPLM(Y_s, as.matrix(X_s), as.matrix(locs_s), params, priors, n_cores = 6L, shared_theta = FALSE, shared_tau = TRUE)
+  out <- pgSPLM(Y_s, as.matrix(X_s), as.matrix(locs_s), params, priors, corr_fun = "exponential", n_cores = 6L, shared_covariance_params = FALSE)
   stop <- Sys.time()
   runtime <- stop - start
   
-  save(out, runtime, file = here::here("results", "pgSPLM-sample.RData"))
+  save(out, runtime, file = here::here("results", "pgSPLM-exponential-sample.RData"))
 }
 ```
 
@@ -795,11 +798,19 @@ if (file.exists(here::here("results", "pgSPLM-sample.RData"))) {
 ```{r}
 layout(matrix(1:6, 3, 2))
 for (i in 1:5) {
-  matplot(out$beta[, , i], type = 'l', main = paste("species", i))
+  matplot(out$beta[, , i], type = 'l', main = paste("species", i), col = 1:nrow(beta))
   abline(h = beta[, i], col = 1:nrow(beta))
 }
-matplot(out$theta, type = 'l', main = "theta")
-abline(h = theta, col = 1:2)
+```
+
+```{r}
+layout(matrix(1:6, 3, 2))
+for (i in 1:5) {
+  matplot(out$theta[, i], type = 'l', main = "theta")
+  abline(h = theta[i], col = 1:2)
+}
+matplot(out$tau2, type = 'l')
+abline(h = tau2, col = 1:length(tau2))
 ```
 
 ```{r}
@@ -807,10 +818,8 @@ layout(matrix(1:6, 3, 2))
 plot_idx <- sample(1:n, 20)
 for (i in 1:5) {
   matplot(out$eta[, plot_idx, i], type = 'l', main = paste("species", i))
-  abline(h = eta_s[plot_idx, i], col = 1:20)
+  abline(h = eta[plot_idx, i], col = 1:20)
 }
-plot(out$tau2, type = 'l', main = "tau2")
-abline(h = tau2, col = "red")
 ```
 
 
@@ -824,8 +833,8 @@ dat_plot <- data.frame(
     c(apply(out$beta, c(2, 3), mean)), 
     c(beta)
   ),
-  type = rep(c("estimate", "truth"), each = (d-1) * ncol(X)),
-  species = factor(rep(1:(d-1), each = ncol(X))),
+  type = rep(c("estimate", "truth"), each = (J-1) * ncol(X)),
+  species = factor(rep(1:(J-1), each = ncol(X))),
   variable = 1:ncol(X)
 )
 
@@ -844,8 +853,8 @@ dat_plot <- data.frame(
     c(apply(out$eta, c(2, 3), mean)), 
     c(eta_s)
   ),
-  type = rep(c("estimate", "truth"), each = (d-1) * n),
-  species = factor(rep(1:(d-1), each = n)),
+  type = rep(c("estimate", "truth"), each = (J-1) * n),
+  species = factor(rep(1:(J-1), each = n)),
   observations = 1:n
 )
 
@@ -862,12 +871,12 @@ p1 + p2
 
 
 ```{r}
-if (file.exists(here::here("results", "pgSPLM-sample-preds.RData"))) {
-  load(here::here("results", "pgSPLM-sample-preds.RData"))
+if (file.exists(here::here("results", "pgSPLM-exponential-sample-preds.RData"))) {
+  load(here::here("results", "pgSPLM-exponential-sample-preds.RData"))
 } else {
   ## currently this is somewhat slow but is embarassingly parallel
-  preds <- predict_pgSPLM(out, X_s, X_oos, locs_s, locs_oos, shared_covariance_params = FALSE)
-  save(preds, file = here::here("results", "pgSPLM-sample-preds.RData"))
+  preds <- predict_pgSPLM(out, X_s, X_oos, locs_s, locs_oos, corr_fun = "exponential", shared_covariance_params = FALSE)
+  save(preds, file = here::here("results", "pgSPLM-exponential-sample-preds.RData"))
 }
 ```
 
@@ -883,13 +892,13 @@ abline(0, 1, col = "red")
 
 ## Plot the simulated data
 
-```{r}
+```{r, fig.width = 2*16, fig.height = 2*9, out.width = "100%"}
 ## put data into data.frame for plotting
 dat <- data.frame(
   Y       = c(rbind(Y_prop_s, Y_prop_oos)),
   lon     = c(locs_s[, 1], locs_oos[, 1]),
   lat     = c(locs_s[, 2], locs_oos[, 2]),
-  species = factor(rep(1:d, each = N)), 
+  species = factor(rep(1:J, each = N)), 
   pi      = c(rbind(pi_s, pi_pred_mean)),
   type    = c(rep("observed", n), rep("predicted", N-n))
 )
@@ -902,7 +911,6 @@ p_predicted <- ggplot(data = dat, aes(x = lon, y = lat, fill = pi)) +
   ggtitle("Predicted latent probability")
 
 p_simulated + p_observed + p_predicted
-
 ```
 
 
@@ -930,3 +938,5 @@ inits  <- default_inits_pgSPLM(Y, X, priors, corr_fun = "exponential" shared_cov
 profvis::profvis(pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, corr_fun = "exponential", n_cores = 1L, shared_covariance_params = FALSE))
 profvis::profvis(pgSPLM(Y, as.matrix(X), as.matrix(locs), params, priors, corr_fun = "exponential", n_cores = 6L, shared_covariance_params = FALSE))
 ```
+
+


### PR DESCRIPTION
Reverts jtipton25/pgR#13

The option to allow specific pooling of parameters for tau2 and theta is producing spaghetti code and is not maintainable or easily testable. Also, I think it's hard to justify a model where tau2 is pooled but theta is component specific (or vice-versa). If you really want these components, they can be added as a special case model rather than in the primary model function.