### PR TITLE
Fix indexes.

### DIFF
--- a/R/pgSTLM.R
+++ b/R/pgSTLM.R
@@ -706,20 +706,20 @@ pgSTLM <- function(
                     ## parallelize this        
                     mh2 <- sum(
                         sapply(1:(J-1), function(j) {
-                            mvnfast::dmvn(eta[, j, 1], Xbeta[, j], Sigma_chol, isChol = TRUE, log = TRUE, ncores = n_cores) 
+                            mvnfast::dmvn(eta[, j, 1], Xbeta[, j], Sigma_chol[j,,], isChol = TRUE, log = TRUE, ncores = n_cores)
                         })
                     ) +
                         sum(
                             sapply(2:n_time, function(tt) {
                                 sapply(1:(J-1), function(j) {
-                                    mvnfast::dmvn(eta[, j, tt], Xbeta[, j] + rho * eta[, j, tt - 1], Sigma_chol, isChol = TRUE, log = TRUE, ncores = n_cores) 
+                                    mvnfast::dmvn(eta[, j, tt], Xbeta[, j] + rho * eta[, j, tt - 1], Sigma_chol[j,,], isChol = TRUE, log = TRUE, ncores = n_cores)
                                 })
                             }) 
                             
                         ) +
                         ## prior
-                        mvnfast::dmvn(theta[j, drop = FALSE], theta_mean, theta_var, log = TRUE)
-                    
+                        mvnfast::dmvn(theta[j, ,drop = FALSE], theta_mean, theta_var, log = TRUE)
+
                     mh <- exp(mh1 - mh2)
                     if (mh > runif(1, 0, 1)) {
                         if (corr_fun == "matern") {


### PR DESCRIPTION
A few index fixes on Sigma_chol and theta in pgSTLM.R (no change to size of objects, just fixing index errors in function necessary to get function to run for corre_fun="matern" shared_covariance_params=FALSE case).